### PR TITLE
IOS-3220: Add a line break before headers

### DIFF
--- a/CocoaMarkdown/CMAttributedStringRenderer.m
+++ b/CocoaMarkdown/CMAttributedStringRenderer.m
@@ -93,6 +93,7 @@
 
 - (void)parser:(CMParser *)parser didStartHeaderWithLevel:(NSInteger)level
 {
+    [self appendLineBreakIfNotTightForNode:parser.currentNode];
     [_attributeStack push:CMDefaultAttributeRun([_attributes attributesForHeaderLevel:level])];
 }
 
@@ -300,6 +301,11 @@
 
 - (void)appendLineBreakIfNotTightForNode:(CMNode *)node
 {
+    // SC: Don't append a line break if we have no string, yet.
+    if ([[_buffer string] length] == 0) {
+        return;
+    }
+
     CMNode *grandparent = node.parent.parent;
     if (!grandparent.listTight) {
         [self appendString:@"\n"];

--- a/CocoaMarkdown/CMAttributedStringRenderer.m
+++ b/CocoaMarkdown/CMAttributedStringRenderer.m
@@ -93,9 +93,12 @@
 
 - (void)parser:(CMParser *)parser didStartHeaderWithLevel:(NSInteger)level
 {
+    // SC: Fix an issue where headers did not have any space before them and were aligned with the
+    // previous text. This didn't look good.
     if ([[_buffer string] length] > 0) {
         [self appendString:@"\n"];
     }
+
     [_attributeStack push:CMDefaultAttributeRun([_attributes attributesForHeaderLevel:level])];
 }
 

--- a/CocoaMarkdown/CMAttributedStringRenderer.m
+++ b/CocoaMarkdown/CMAttributedStringRenderer.m
@@ -93,7 +93,9 @@
 
 - (void)parser:(CMParser *)parser didStartHeaderWithLevel:(NSInteger)level
 {
-    [self appendLineBreakIfNotTightForNode:parser.currentNode];
+    if ([[_buffer string] length] > 0) {
+        [self appendString:@"\n"];
+    }
     [_attributeStack push:CMDefaultAttributeRun([_attributes attributesForHeaderLevel:level])];
 }
 

--- a/CocoaMarkdownTests/Resources/test.md
+++ b/CocoaMarkdownTests/Resources/test.md
@@ -31,6 +31,10 @@ Here is yet another list:
 - Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
 - Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
 
+Here is an inline header:
+
+# 可視化されない「都市難民」
+
 ![Image](https://raw.githubusercontent.com/sonoramac/Sonora/master/screenshot.png "screenshot")
 
 ---


### PR DESCRIPTION
The old code did not add a line break before headers, which caused them to look strange when they were anywhere but at the beginning of the block of text. Fix that, but be careful that we don't add extra line breaks at the beginning of the text.

[IOS-3220](https://buzzfeed.atlassian.net/browse/IOS-3220)